### PR TITLE
Remove `no-unused-variable` TS Lint rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@reedsy/eslint-config-reedsy",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/eslint-config-reedsy",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Common eslint config",
   "main": "eslint.yaml",
   "scripts": {

--- a/tslint.yaml
+++ b/tslint.yaml
@@ -46,7 +46,6 @@ rules:
   no-string-throw: true
   no-this-assignment: true
   no-unsafe-finally: true
-  no-unused-variable: true
   no-var-keyword: true
   restrict-plus-operands: true
   switch-default:


### PR DESCRIPTION
`tslint` has deprecated the `no-unused-variable` rule, which should be
replaced by using the compiler options `noUnusedLocals` and
`noUnusedParameters`.