### PR TITLE
Relax class methods and return assign rules

### DIFF
--- a/eslint.yaml
+++ b/eslint.yaml
@@ -8,7 +8,7 @@ rules:
   complexity:
   - 'off'
   - 11
-  class-methods-use-this: warn
+  class-methods-use-this: 'off'
   consistent-return: 'off'
   curly:
   - error
@@ -114,9 +114,7 @@ rules:
   - object: Math
     property: pow
     message: Use the exponentiation operator (**) instead.
-  no-return-assign:
-  - error
-  - always
+  no-return-assign: 'off'
   no-return-await: error
   no-script-url: error
   no-self-assign: error

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "@reedsy/eslint-config-reedsy",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/eslint-config-reedsy",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Common eslint config",
   "main": "eslint.yaml",
   "scripts": {


### PR DESCRIPTION
When writing ES6 classes, we don't always reference `this`, and the
linter creates a lot of noise.

We also sometimes want to write one-line lambdas with an assignment.