### PR TITLE
Use TypeScript-safe version of `indent` rule

### DIFF
--- a/eslint.yaml
+++ b/eslint.yaml
@@ -16,11 +16,8 @@ rules:
     - code: 120
       ignorePattern: '^import '
       ignoreUrls: true
-  # 2 spaces means nested code doesn't drift too far across the screen
-  indent:
-    - error
-    - 2
-    - SwitchCase: 1
+  # Use the TypesScript-safe version
+  indent: off
   # Google enforces this, but TypeScript is enough documentation for us
   require-jsdoc: off
   valid-jsdoc: off
@@ -73,6 +70,11 @@ rules:
     - always
   '@typescript-eslint/explicit-member-accessibility':
     - error
+    # 2 spaces means nested code doesn't drift too far across the screen
+  '@typescript-eslint/indent':
+    - error
+    - 2
+    - SwitchCase: 1
 overrides:
   - files:
     - '*.spec.ts'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/eslint-config-reedsy",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/eslint-config-reedsy",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Common eslint config",
   "main": "eslint.yaml",
   "scripts": {


### PR DESCRIPTION
Fixes [this issue][1].

[1]: https://github.com/typescript-eslint/typescript-eslint/issues/792