### PR TITLE
Add quotes rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,8 @@ anti-patterns.
 
 ## Installation
 
-Install this package like any other of our private packages, by updating `package.json` eg:
-
-```json
-{
-  "devDependencies:" {
-    "@reedsy/eslint-config-reedsy": "git+ssh://git@github.com/reedsy/eslint-config-reedsy#1.0.0"
-  }
-}
+```bash
+npm i @reedsy/eslint-config-reedsy --save-dev
 ```
 
 You'll also need to install the peer dependencies:

--- a/eslint.yaml
+++ b/eslint.yaml
@@ -33,6 +33,11 @@ rules:
   quote-props:
     - error
     - as-needed
+  # The default rules are a bit liberal (eg allow unnecessary backticks)
+  quotes:
+    - error
+    - single
+    - avoidEscape: true
 
   ### TYPESCRIPT ###
   # Disabling explicit any is pretty annoying when also using

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/eslint-config-reedsy",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "Common eslint config",
   "main": "eslint.yaml",
   "scripts": {
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/reedsy/eslint-config-reedsy.git"
+    "url": "git://github.com/reedsy/eslint-config-reedsy.git"
   },
   "author": "Alec Gibson",
   "license": "ISC",


### PR DESCRIPTION
This change adds a quotes rule to our rule overrides. The Google rule is
a little bit liberal, and allows use of unnecessary backticks, which can
sometimes be confusing, as they should only be used for string
interpolation.