### PR TITLE
Bump `@typescript-eslint` dependencies

### DIFF
--- a/eslint.yaml
+++ b/eslint.yaml
@@ -2,7 +2,6 @@ parserOptions:
   parser: '@typescript-eslint/parser'
 extends:
   - 'google'
-  - 'plugin:@typescript-eslint/eslint-recommended'
   - 'plugin:@typescript-eslint/recommended'
   - 'plugin:vue/recommended'
 plugins:
@@ -51,13 +50,16 @@ rules:
       classes: false
   # Sometimes modules don't have type definitions, so we need to require them
   '@typescript-eslint/no-var-requires': off
-  # Makes it clear which files are interfaces, and leaves the un-prefixed
-  # name available to be a class (without needing eg an 'Impl' suffix)
-  '@typescript-eslint/interface-name-prefix':
+  '@typescript-eslint/naming-convention':
     - error
-    - prefixWithI: always
-  # Allow extending an interface, so that our extension of io-ts built
-  # interfaces doesn't trigger this
+    # Makes it clear which files are interfaces, and leaves the un-prefixed
+    # name available to be a class (without needing eg an 'Impl' suffix)
+    - selector: interface
+      format:
+      - PascalCase
+      custom:
+        regex: ^I[A-Z]
+        match: true
   '@typescript-eslint/no-empty-interface':
     - error
     - allowSingleExtends: true
@@ -80,6 +82,15 @@ rules:
     - error
     - 2
     - SwitchCase: 1
+  '@typescript-eslint/explicit-module-boundary-types':
+    - warn
+    # We should trust ourselves to use any when appropriate
+    - allowArgumentsExplicitlyTypedAsAny: true
+      allowHigherOrderFunctions: true
+      allowTypedFunctionExpressions: true
+  # The default options are a bit aggressive and ban eg Function, which
+  # sometimes has legitimate use
+  '@typescript-eslint/ban-types': off
 overrides:
   - files:
     - '*.spec.ts'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/eslint-config-reedsy",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Common eslint config",
   "main": "eslint.yaml",
   "scripts": {
@@ -20,10 +20,10 @@
   },
   "homepage": "https://github.com/reedsy/eslint-config-reedsy#readme",
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.12.0",
-    "@typescript-eslint/parser": "^2.11.0",
+    "@typescript-eslint/eslint-plugin": "^3.10.1",
+    "@typescript-eslint/parser": "^3.10.1",
     "eslint-config-google": "^0.14.0",
-    "eslint-plugin-vue": "^5.2.2"
+    "eslint-plugin-vue": "^6.2.2"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
This change bumps our `@typesript-eslint` dependencies through a major
version bump, and tweaks our config accordingly.