### PR TITLE
Disable `camelcase` rule

### DIFF
--- a/eslint.yaml
+++ b/eslint.yaml
@@ -37,6 +37,8 @@ rules:
     - error
     - single
     - avoidEscape: true
+  # We use @typescript/naming-convention instead
+  camelcase: off
 
   ### TYPESCRIPT ###
   # Disabling explicit any is pretty annoying when also using

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/eslint-config-reedsy",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Common eslint config",
   "main": "eslint.yaml",
   "scripts": {


### PR DESCRIPTION
The built-in `eslint` rule `camelcase` conflicts with our
`@typescript/naming-convention` rules, so let's disable it.