### PR TITLE
🚨 Enforce consistent line spacing

### DIFF
--- a/eslint.yaml
+++ b/eslint.yaml
@@ -39,6 +39,14 @@ rules:
     - avoidEscape: true
   # We use @typescript/naming-convention instead
   camelcase: off
+  # Keep consistent spacing
+  no-multiple-empty-lines:
+    - error
+    - max: 1
+  lines-between-class-members:
+    - error
+    - always
+    - exceptAfterSingleLine: true
 
   ### TYPESCRIPT ###
   # Disabling explicit any is pretty annoying when also using

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/eslint-config-reedsy",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Common eslint config",
   "main": "eslint.yaml",
   "scripts": {


### PR DESCRIPTION
We should have consistent spacing in our code. This change sets it so
we should always have at most a single line of whitespace, and we should
always have space between class methods.