### PR TITLE
🚨 Enforce consistent function parameter line spacing

### DIFF
--- a/eslint.yaml
+++ b/eslint.yaml
@@ -47,6 +47,9 @@ rules:
     - error
     - always
     - exceptAfterSingleLine: true
+  function-paren-newline:
+    - error
+    - multiline-arguments
 
   ### TYPESCRIPT ###
   # Disabling explicit any is pretty annoying when also using

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/eslint-config-reedsy",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Common eslint config",
   "main": "eslint.yaml",
   "scripts": {


### PR DESCRIPTION
This change adds the [`function-paren-newline`][1] rule, which enforces
consistent line spacing of function arguments.

[1]: https://eslint.org/docs/rules/function-paren-newline