### PR TITLE
🚨 Enable `space-infix-ops`

### DIFF
--- a/eslint.yaml
+++ b/eslint.yaml
@@ -50,6 +50,8 @@ rules:
   function-paren-newline:
     - error
     - multiline-arguments
+  # Consistent operator spacing
+  space-infix-ops: error
 
   ### TYPESCRIPT ###
   # Disabling explicit any is pretty annoying when also using

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reedsy/eslint-config-reedsy",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Common eslint config",
   "main": "eslint.yaml",
   "scripts": {


### PR DESCRIPTION
This change ensures we have consistent operator spacing